### PR TITLE
html-css-examples 1.1.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 
-# HTML & CSS Examples [![PayPal](https://img.shields.io/badge/%24-paypal-f39c12.svg)][paypal-donations] [![Version](https://img.shields.io/npm/v/html-css-examples.svg)](https://www.npmjs.com/package/html-css-examples) [![Downloads](https://img.shields.io/npm/dt/html-css-examples.svg)](https://www.npmjs.com/package/html-css-examples) [![Get help on Codementor](https://cdn.codementor.io/badges/get_help_github.svg)](https://www.codementor.io/johnnyb?utm_source=github&utm_medium=button&utm_term=johnnyb&utm_campaign=github)
+# HTML & CSS Examples
+
+ [![PayPal](https://img.shields.io/badge/%24-paypal-f39c12.svg)][paypal-donations] [![AMA](https://img.shields.io/badge/ask%20me-anything-1abc9c.svg)](https://github.com/IonicaBizau/ama) [![Version](https://img.shields.io/npm/v/html-css-examples.svg)](https://www.npmjs.com/package/html-css-examples) [![Downloads](https://img.shields.io/npm/dt/html-css-examples.svg)](https://www.npmjs.com/package/html-css-examples) [![Get help on Codementor](https://cdn.codementor.io/badges/get_help_github.svg)](https://www.codementor.io/johnnyb?utm_source=github&utm_medium=button&utm_term=johnnyb&utm_campaign=github)
 
 > A collection of HTML and CSS examples.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "html-css-examples",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "A collection of HTML and CSS examples.",
   "main": "lib/index.js",
   "scripts": {
@@ -49,6 +49,7 @@
     "src/",
     "resources/",
     "menu/",
+    "scripts/",
     "cli.js",
     "index.js"
   ]


### PR DESCRIPTION
- Updated the README.md following the new template. :memo:
- Use [`babel-it`](https://github.com/IonicaBizau/babel-it) to babelify the code, so the module is now compatible with older versions of Node.js.
